### PR TITLE
Add newline to missing expression message

### DIFF
--- a/calc.c
+++ b/calc.c
@@ -57,7 +57,7 @@ int parseOptions(int argc, char* argv[]) {
 			return i;
 	}
 	
-	fprintf(stderr, "calc: Expression missing.\nUsage: calc [OPTIONS] EXPRESSIONS.\nTry 'calc --help' for more information.");
+	fprintf(stderr, "calc: Expression missing.\nUsage: calc [OPTIONS] EXPRESSIONS.\nTry 'calc --help' for more information.\n");
 	exit(-1);
 }
 


### PR DESCRIPTION
### Without newline

```
jan@svadlupnir $ ./calc 
calc: Expression missing.
Usage: calc [OPTIONS] EXPRESSIONS.
Try 'calc --help' for more information.jan@svadlupnir $
```

### With newline

```
jan@svadlupnir $ ./calc 
calc: Expression missing.
Usage: calc [OPTIONS] EXPRESSIONS.
Try 'calc --help' for more information.
jan@svadlupnir $
```