### PR TITLE
Fix V614 warning from PVS-Studio Static Analyzer

### DIFF
--- a/calc.c
+++ b/calc.c
@@ -139,6 +139,7 @@ int execute(struct token temp) {
 		}
 		
 		d1 = outStack[--outCount];
+                result = d1;
 		
 		if(temp.subType == SIN)
 			result = USE_DEGREE ? sin(toRadians(d1)) : sin(d1);


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio.

Warning:
[V614](https://www.viva64.com/en/w/v614) Potentially uninitialized variable 'result' used.